### PR TITLE
fix typo in example config in code

### DIFF
--- a/plugins/inputs/modbus/modbus.go
+++ b/plugins/inputs/modbus/modbus.go
@@ -113,7 +113,7 @@ var ModbusConfig = `
     ]
 
   [[inputs.modbus.Registers.InputRegisters.Tags]]
-    name = "Frecuency"
+    name = "Frequency"
     order ="AB"	
     scale = "/10"
     address = [


### PR DESCRIPTION
One more place to fix this typo, this time in default config in code. 

Didn't make it with this change before your merge of PR. 